### PR TITLE
Feat/#9: 나의 질문(대시보드) CRUD 기능 구현

### DIFF
--- a/app/(app)/questions/page.tsx
+++ b/app/(app)/questions/page.tsx
@@ -1,0 +1,18 @@
+import MyQuestionsHeader from '@/features/my-questions/components/MyQuestionsHeader';
+import MyQuestionsSearchbar from '@/features/my-questions/components/MyQuestionsSearchbar';
+import { QuestionFormModal } from '@/features/my-questions/components/QuestionFormModal';
+import QuestionList from '@/features/my-questions/components/QuestionList';
+
+export default function MyQuestionsPage() {
+  return (
+    <div className='p-4'>
+      <MyQuestionsHeader />
+
+      <MyQuestionsSearchbar />
+
+      <QuestionList />
+
+      <QuestionFormModal />
+    </div>
+  );
+}

--- a/features/dashboard/components/ScheduleItem.tsx
+++ b/features/dashboard/components/ScheduleItem.tsx
@@ -3,12 +3,15 @@
 import { Interview } from '@/shared/types/interview';
 
 interface ScheduleItemProps {
-  interview: Interview; // 구체적인 인터페이스 정의 권장
+  interview: Interview & {
+    companyName?: string;
+    title?: string;
+  }; // 구체적인 인터페이스 정의 권장
   onClick: () => void;
 }
 
 export const ScheduleItem = ({ interview, onClick }: ScheduleItemProps) => {
-  const isUpcoming = new Date(interview.scheduledAt) > new Date();
+  const isUpcoming = new Date(interview.datetime) > new Date();
 
   return (
     <div

--- a/features/my-questions/api/questions.ts
+++ b/features/my-questions/api/questions.ts
@@ -1,0 +1,71 @@
+import { clientApi } from '@/shared/lib/api/clientApi';
+import { GetQuestionsResponse } from '../types';
+
+/**
+ * [GET] 개인 면접 질문 목록 조회 (커서 기반 페이지네이션)
+ * @param lastCursorId 마지막으로 조회한 질문 ID (커서)
+ * @param size 한 번에 조회할 데이터 개수 (기본값 20)
+ */
+export const getQuestions = async (
+  lastCursorId?: number,
+  size: number = 20
+): Promise<GetQuestionsResponse> => {
+  const params = new URLSearchParams({
+    size: String(size),
+    ...(lastCursorId && { lastCursorId: String(lastCursorId) }),
+  });
+
+  return clientApi.get<GetQuestionsResponse>(`/v1/archive/questions?${params}`);
+};
+
+/** 질문 등록 응답 타입 */
+export interface CreateQuestionResponse {
+  id: number;
+  applicationId: number | null;
+  interviewQuestionId: number | null;
+  question: string;
+  answer: string;
+  fromCommunity: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * 개인 면접 질문 등록 API
+ * @param body - 질문 및 답변 데이터
+ * @param applicationId - 선택사항 (특정 지원 카드와 연결 시)
+ */
+export const createQuestion = async (
+  body: {
+    company: string;
+    position: string;
+    question: string;
+    interviewType: string;
+    answer?: string;
+  },
+  applicationId?: number
+): Promise<CreateQuestionResponse> => {
+  const queryString = applicationId ? `?applicationId=${applicationId}` : '';
+
+  return clientApi.post<CreateQuestionResponse>(
+    `v1/archive/questions${queryString}`,
+    body
+  );
+};
+
+export const updateQuestion = async (
+  questionId: number,
+  body: {
+    company: string;
+    position: string;
+    question: string;
+    interviewType: string;
+    answer?: string;
+  }
+) => {
+  return clientApi.patch(`v1/archive/questions/${questionId}`, body);
+};
+
+export const deleteQuestion = async (questionId: number) => {
+  return clientApi.delete(`v1/archive/questions/${questionId}`);
+};

--- a/features/my-questions/components/EmptyQuestion.tsx
+++ b/features/my-questions/components/EmptyQuestion.tsx
@@ -1,0 +1,12 @@
+import { BookMarkedIcon } from 'lucide-react';
+
+export default function EmptyQuestion() {
+  return (
+    <div className='text-center py-12 bg-slate-50 dark:bg-slate-900 rounded-2xl border border-dashed border-slate-200 dark:border-slate-800'>
+      <BookMarkedIcon className='w-12 h-12 text-slate-300 dark:text-slate-700 mx-auto mb-3' />
+      <p className='text-slate-500 dark:text-slate-400 font-medium'>
+        검색 결과가 없거나 저장된 질문이 없습니다.
+      </p>
+    </div>
+  );
+}

--- a/features/my-questions/components/MyQuestionsHeader.tsx
+++ b/features/my-questions/components/MyQuestionsHeader.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { BookMarkedIcon, PlusIcon } from 'lucide-react';
+import { useQuestionModalStore } from '../store/useQuestionModalStore';
+
+export default function MyQuestionsHeader() {
+  const openCreateModal = useQuestionModalStore(
+    (state) => state.openCreateModal
+  );
+
+  const handleClickAddQuestionButton = () => {
+    openCreateModal();
+  };
+
+  return (
+    <div className='flex flex-col md:flex-row justify-between items-start md:items-center mb-8 gap-4'>
+      <div>
+        <h1 className='text-2xl font-bold text-slate-900 dark:text-slate-100 flex items-center'>
+          <BookMarkedIcon className='w-6 h-6 mr-2 text-brand-500' />
+          나만의 면접 질문 모음
+        </h1>
+        <p className='text-slate-500 dark:text-slate-400 mt-1'>
+          커뮤니티에서 저장한 면접 질문들을 복습해보세요.
+        </p>
+      </div>
+      <button
+        onClick={handleClickAddQuestionButton}
+        className='px-4 py-2.5 bg-brand-500 text-white rounded-xl font-bold hover:bg-brand-600 flex items-center space-x-2 transition-all shadow-lg'
+      >
+        <PlusIcon className='w-5 h-5' />
+        <span>질문 추가</span>
+      </button>
+    </div>
+  );
+}

--- a/features/my-questions/components/MyQuestionsSearchbar.tsx
+++ b/features/my-questions/components/MyQuestionsSearchbar.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { SearchIcon } from 'lucide-react';
+import { useState } from 'react';
+
+export default function MyQuestionsSearchbar() {
+  const [search, setSearch] = useState('');
+
+  return (
+    <div className='mb-6 relative'>
+      <SearchIcon className='absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400' />
+      <input
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        className='w-full pl-9 pr-4 py-3 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-xl focus:ring-2 focus:ring-brand-500 outline-none dark:text-slate-100'
+        placeholder='회사명으로 검색...'
+      />
+    </div>
+  );
+}

--- a/features/my-questions/components/QuestionFormModal.tsx
+++ b/features/my-questions/components/QuestionFormModal.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/shared/components/ui/dialog';
+import { useQuestionModalStore } from '../store/useQuestionModalStore';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared/components/ui/select';
+import { SaveIcon } from 'lucide-react';
+import { INTERVIEW_PRESETS } from '@/shared/constants/interview';
+import { Controller, useForm } from 'react-hook-form';
+import { useEffect } from 'react';
+import { Textarea } from '@/shared/components/ui/textarea';
+import { Label } from '@/shared/components/ui/label';
+import { Input } from '@/shared/components/ui/input';
+import { Button } from '@/shared/components/ui/button';
+import { useQuestions } from '../hooks/useQuestions';
+
+const questionSchema = z.object({
+  interviewType: z.string().min(1, '면접 종류를 선택해주세요.'),
+  companyName: z.string().min(1, '회사명을 입력해주세요.'),
+  position: z.string().min(1, '직무를 입력해주세요.'),
+  question: z.string().min(1, '질문 내용을 입력해주세요.'),
+  answer: z.string().optional(), // API 명세에 따라 추가 가능
+});
+
+export type QuestionFormValues = z.infer<typeof questionSchema>;
+
+export const QuestionFormModal = () => {
+  const { isOpen, closeModal, mode, selectedQuestion } =
+    useQuestionModalStore();
+  const { createMutation, updateMutation } = useQuestions();
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    formState: { errors },
+  } = useForm<QuestionFormValues>({
+    resolver: zodResolver(questionSchema),
+    defaultValues: {
+      question: '',
+      companyName: '',
+      position: '',
+      interviewType: '',
+      answer: '',
+    },
+  });
+
+  // 모달이 열릴 때/수정 데이터가 들어올 때 폼 초기화
+  useEffect(() => {
+    if (isOpen) {
+      if (mode === 'edit' && selectedQuestion) {
+        reset({
+          ...selectedQuestion,
+          companyName: selectedQuestion.company,
+        });
+      } else {
+        reset({
+          question: '',
+          companyName: '',
+          position: '',
+          interviewType: '',
+          answer: '',
+        });
+      }
+    }
+  }, [isOpen, mode, selectedQuestion, reset]);
+
+  const onSubmit = (data: QuestionFormValues) => {
+    if (mode === 'create') {
+      createMutation.mutate(data);
+    } else {
+      if (!selectedQuestion?.id) return;
+
+      updateMutation.mutate({
+        id: selectedQuestion.id,
+        body: data,
+      });
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const isLoading = createMutation.isPending || updateMutation.isPending;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && closeModal()}>
+      <DialogContent className='sm:max-w-md'>
+        <DialogHeader>
+          <DialogTitle>
+            {mode === 'create' ? '새 질문 추가' : '질문 수정'}
+          </DialogTitle>
+        </DialogHeader>
+
+        <form
+          onSubmit={handleSubmit(onSubmit, (errors) =>
+            console.log('검증 실패 원인:', errors)
+          )}
+          className='space-y-4'
+        >
+          <div className='space-y-1.5'>
+            <Label
+              htmlFor='interviewType'
+              className='block text-sm font-bold text-slate-700 dark:text-slate-300 mb-1.5'
+            >
+              면접 종류 <span className='text-red-500'>*</span>
+            </Label>
+            <Controller
+              name='interviewType'
+              control={control}
+              render={({ field }) => (
+                <Select onValueChange={field.onChange} value={field.value}>
+                  <SelectTrigger
+                    id='interviewType'
+                    className='w-full h-[50px] rounded-xl bg-slate-50 dark:bg-slate-800 border-slate-200'
+                  >
+                    <SelectValue placeholder='면접 종류를 선택하세요' />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {INTERVIEW_PRESETS.map((p) => (
+                      <SelectItem key={p.value} value={p.value}>
+                        {p.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            />
+            {errors.interviewType && (
+              <p className='text-xs text-red-500'>
+                {errors.interviewType.message}
+              </p>
+            )}
+          </div>
+
+          <div className='grid grid-cols-2 gap-3'>
+            <div className='space-y-1.5'>
+              <Label
+                htmlFor='companyName'
+                className='block text-sm font-bold text-slate-700 dark:text-slate-300 mb-1.5'
+              >
+                회사명 <span className='text-red-500'>*</span>
+              </Label>
+              <Input
+                {...register('companyName')}
+                id='companyName'
+                required
+                placeholder='회사명 *'
+                className='p-3 border rounded-xl bg-slate-50 dark:bg-slate-800'
+              />
+              {errors.companyName && (
+                <p className='text-xs text-red-500'>
+                  {errors.companyName.message}
+                </p>
+              )}
+            </div>
+
+            <div className='space-y-1.5'>
+              <Label
+                htmlFor='position'
+                className='block text-sm font-bold text-slate-700 dark:text-slate-300 mb-1.5'
+              >
+                직무 <span className='text-red-500'>*</span>
+              </Label>
+              <Input
+                {...register('position')}
+                id='position'
+                required
+                placeholder='직무 *'
+                className='w-full p-3 border rounded-xl bg-slate-50 dark:bg-slate-800'
+              />
+              {errors.position && (
+                <p className='text-xs text-red-500'>
+                  {errors.position.message}
+                </p>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <Label
+              htmlFor='question'
+              className='block text-sm font-bold text-slate-700 dark:text-slate-300 mb-1.5'
+            >
+              질문 내용 <span className='text-red-500'>*</span>
+            </Label>
+            <Textarea
+              id='question'
+              required
+              {...register('question')}
+              className='w-full p-3 border rounded-xl bg-slate-50 dark:bg-slate-800 h-20'
+            />
+            {errors.question && (
+              <p className='text-xs text-red-500'>{errors.question.message}</p>
+            )}
+          </div>
+
+          <div>
+            <Label
+              htmlFor='answer'
+              className='block text-sm font-bold text-slate-700 dark:text-slate-300 mb-1.5'
+            >
+              메모
+            </Label>
+            <Textarea
+              id='answer'
+              {...register('answer')}
+              className='w-full p-3 border rounded-xl bg-slate-50 dark:bg-slate-800 h-20'
+            />
+            {errors.answer && (
+              <p className='text-xs text-red-500'>{errors.answer.message}</p>
+            )}
+          </div>
+
+          <div className='flex gap-x-2'>
+            <Button
+              type='button'
+              onClick={closeModal}
+              variant='outline'
+              className='flex-1'
+              disabled={isLoading}
+            >
+              취소
+            </Button>
+            <Button
+              type='submit'
+              variant='default'
+              className='flex-1 font-bold flex items-center justify-center'
+              disabled={isLoading}
+            >
+              {isLoading ? (
+                <span className='animate-spin mr-2'>...</span>
+              ) : (
+                <SaveIcon size={16} className='mr-2' />
+              )}
+              <span>{mode === 'create' ? '저장하기' : '수정 완료'}</span>
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/features/my-questions/components/QuestionItem.tsx
+++ b/features/my-questions/components/QuestionItem.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { Building2, Briefcase, Edit2, Trash2 } from 'lucide-react';
+import { QuestionItem as QuestionItemType } from '../types';
+import { useQuestionModalStore } from '../store/useQuestionModalStore';
+import { useConfirmStore } from '@/shared/stores/useConfirmStore';
+import { useQuestions } from '../hooks/useQuestions';
+import { INTERVIEW_LABEL_MAP } from '@/shared/constants/interview';
+import { RelativeTime } from '@/shared/components/RelativeTime';
+
+interface QuestionItemProps {
+  question: QuestionItemType;
+}
+
+export const QuestionItem = ({ question }: QuestionItemProps) => {
+  const { deleteMutation } = useQuestions();
+  const openEditModal = useQuestionModalStore((state) => state.openEditModal);
+  const openConfirm = useConfirmStore((state) => state.openConfirm);
+
+  const handleClickEditButton = () => {
+    openEditModal(question);
+  };
+
+  const handleClickDeleteButton = () => {
+    openConfirm({
+      title: '정말 삭제하시겠습니까?',
+      description:
+        '삭제된 질문은 복구할 수 없으며, 모든 답변 데이터가 함께 삭제됩니다.',
+      confirmText: '삭제하기',
+      variant: 'destructive',
+      onConfirm: () => {
+        deleteMutation.mutate(question.id);
+      },
+    });
+  };
+
+  return (
+    <div className='bg-white dark:bg-slate-900 p-5 rounded-2xl border border-slate-200 dark:border-slate-800 shadow-sm hover:border-brand-300 dark:hover:border-brand-700 transition-all group'>
+      <div className='flex justify-between items-start'>
+        <div className='flex-1 min-w-0'>
+          <div className='flex flex-wrap items-center gap-2 text-xs font-semibold text-slate-500 dark:text-slate-400 mb-2'>
+            <div className='flex items-center gap-1'>
+              <Building2 className='w-3.5 h-3.5' />
+              <span>{question.company}</span>
+            </div>
+            <span className='text-slate-300 dark:text-slate-700'>|</span>
+            <div className='flex items-center gap-1'>
+              <Briefcase className='w-3.5 h-3.5' />
+              <span>{question.position}</span>
+            </div>
+            <span className='text-slate-300 dark:text-slate-700'>|</span>
+            <span>{INTERVIEW_LABEL_MAP[question.interviewType]}</span>
+          </div>
+          <h3 className='text-lg font-bold text-slate-800 dark:text-slate-200 leading-snug wrap-break-words'>
+            {question.question}
+          </h3>
+          {question.answer && (
+            <div className='mt-3 p-3 bg-slate-50 dark:bg-slate-800/50 rounded-lg text-sm text-slate-600 dark:text-slate-400'>
+              <span className='font-bold text-slate-400 mr-2'>메모</span>
+              {question.answer}
+            </div>
+          )}
+        </div>
+        <div className='flex items-center space-x-1 ml-4 shrink-0'>
+          <button
+            onClick={handleClickEditButton}
+            className='p-2 text-slate-300 hover:text-brand-500 hover:bg-brand-50 dark:hover:bg-brand-900/30 rounded-lg transition-colors'
+            title='수정'
+          >
+            <Edit2 className='w-5 h-5' />
+          </button>
+          <button
+            onClick={handleClickDeleteButton}
+            className='p-2 text-slate-300 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/30 rounded-lg transition-colors'
+            title='삭제'
+          >
+            <Trash2 className='w-5 h-5' />
+          </button>
+        </div>
+      </div>
+      <div className='mt-3 text-[10px] text-slate-400 text-right uppercase tracking-wider'>
+        <RelativeTime date={question.updatedAt} />
+      </div>
+    </div>
+  );
+};

--- a/features/my-questions/components/QuestionItemSkeleton.tsx
+++ b/features/my-questions/components/QuestionItemSkeleton.tsx
@@ -1,0 +1,42 @@
+import { Skeleton } from '@/shared/components/ui/skeleton';
+
+export const QuestionItemSkeleton = () => {
+  return (
+    <div className='bg-white dark:bg-slate-900 p-5 rounded-2xl border border-slate-200 dark:border-slate-800 shadow-sm'>
+      <div className='flex justify-between items-start'>
+        <div className='flex-1'>
+          {/* 상단 메타 정보 (회사, 직무 등) */}
+          <div className='flex items-center gap-2 mb-3'>
+            <Skeleton className='h-3 w-16' />
+            <Skeleton className='h-3 w-3' />
+            <Skeleton className='h-3 w-20' />
+            <Skeleton className='h-3 w-3' />
+            <Skeleton className='h-3 w-12' />
+          </div>
+
+          {/* 질문 제목 (2줄 정도 예상) */}
+          <div className='space-y-2'>
+            <Skeleton className='h-5 w-[80%]' />
+            <Skeleton className='h-5 w-[40%]' />
+          </div>
+
+          {/* 메모 부분 */}
+          <div className='mt-4 p-3 bg-slate-50 dark:bg-slate-800/50 rounded-lg'>
+            <Skeleton className='h-4 w-full' />
+          </div>
+        </div>
+
+        {/* 우측 버튼 아이콘 자리 */}
+        <div className='flex space-x-2 ml-4'>
+          <Skeleton className='h-9 w-9 rounded-lg' />
+          <Skeleton className='h-9 w-9 rounded-lg' />
+        </div>
+      </div>
+
+      {/* 하단 날짜 */}
+      <div className='mt-4 flex justify-end'>
+        <Skeleton className='h-2 w-16' />
+      </div>
+    </div>
+  );
+};

--- a/features/my-questions/components/QuestionList.tsx
+++ b/features/my-questions/components/QuestionList.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useInView } from '@/shared/hooks/useInView';
+import { useQuestions } from '../hooks/useQuestions';
+import EmptyQuestion from './EmptyQuestion';
+import { QuestionItem } from './QuestionItem';
+import { useEffect } from 'react';
+import { Loader2Icon } from 'lucide-react';
+import { QuestionListSkeleton } from './QuestionListSkeleton';
+
+export default function QuestionList() {
+  const {
+    query: { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading },
+  } = useQuestions();
+
+  const { ref, inView } = useInView({
+    threshold: 0.1,
+    rootMargin: '100px',
+  });
+
+  useEffect(() => {
+    if (inView && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  // 첫 로딩 시 스켈레톤 표시
+  if (isLoading) {
+    return <QuestionListSkeleton />;
+  }
+
+  // 데이터가 비어있을 때 (data가 undefined일 수 있으므로 옵셔널 체이닝 확인)
+  const questions = data?.questions || [];
+  if (questions.length === 0) {
+    return <EmptyQuestion />;
+  }
+
+  return (
+    <div className='space-y-4'>
+      {questions.map((question) => (
+        <QuestionItem key={question.id} question={question} />
+      ))}
+
+      {/* 무한 스크롤 트리거 요소 */}
+      {hasNextPage && (
+        <div ref={ref} className='h-10 flex justify-center items-center'>
+          {isFetchingNextPage && (
+            <Loader2Icon className='w-6 h-6 animate-spin text-slate-400' />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/features/my-questions/components/QuestionListSkeleton.tsx
+++ b/features/my-questions/components/QuestionListSkeleton.tsx
@@ -1,0 +1,12 @@
+import { QuestionItemSkeleton } from './QuestionItemSkeleton';
+
+export const QuestionListSkeleton = () => {
+  return (
+    <div className='space-y-4 w-full'>
+      {/* 5개의 스켈레톤 아이템을 생성 */}
+      {Array.from({ length: 5 }).map((_, i) => (
+        <QuestionItemSkeleton key={i} />
+      ))}
+    </div>
+  );
+};

--- a/features/my-questions/hooks/useQuestions.tsx
+++ b/features/my-questions/hooks/useQuestions.tsx
@@ -1,0 +1,74 @@
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query';
+import {
+  createQuestion,
+  deleteQuestion,
+  getQuestions,
+  updateQuestion,
+} from '../api/questions';
+import { QuestionFormValues } from '../components/QuestionFormModal';
+import { useQuestionModalStore } from '../store/useQuestionModalStore';
+
+export const useQuestions = () => {
+  const queryClient = useQueryClient();
+  const closeModal = useQuestionModalStore((state) => state.closeModal);
+
+  const query = useInfiniteQuery({
+    queryKey: ['questions'],
+    queryFn: async ({ pageParam }) => {
+      return getQuestions(pageParam, 4);
+    },
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) => {
+      // 서버 응답(GetQuestionsResponse)의 hasNext가 true일 때만 차기 커서 반환
+      return lastPage.hasNext ? lastPage.nextCursorId : undefined;
+    },
+    select: (data) => ({
+      pages: data.pages,
+      pageParams: data.pageParams,
+      // 모든 페이지의 질문들을 하나의 배열로 합침
+      questions: data.pages.flatMap((page) => page.questions),
+    }),
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (data: QuestionFormValues) =>
+      createQuestion({
+        ...data,
+        company: data.companyName,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['questions'] });
+      closeModal();
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, body }: { id: number; body: QuestionFormValues }) =>
+      updateQuestion(id, {
+        ...body,
+        company: body.companyName,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['questions'] });
+      closeModal();
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteQuestion(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['questions'] });
+    },
+  });
+
+  return {
+    query,
+    createMutation,
+    updateMutation,
+    deleteMutation,
+  };
+};

--- a/features/my-questions/store/useQuestionModalStore.ts
+++ b/features/my-questions/store/useQuestionModalStore.ts
@@ -1,0 +1,37 @@
+import { create } from 'zustand';
+import { QuestionItem } from '../types';
+
+interface QuestionModalState {
+  isOpen: boolean;
+  mode: 'create' | 'edit';
+  selectedQuestion: QuestionItem | null;
+  // 액션
+  openCreateModal: () => void;
+  openEditModal: (question: QuestionItem) => void;
+  closeModal: () => void;
+}
+
+export const useQuestionModalStore = create<QuestionModalState>((set) => ({
+  isOpen: false,
+  mode: 'create',
+  selectedQuestion: null,
+
+  openCreateModal: () =>
+    set({
+      isOpen: true,
+      mode: 'create',
+      selectedQuestion: null,
+    }),
+
+  openEditModal: (question) =>
+    set({
+      isOpen: true,
+      mode: 'edit',
+      selectedQuestion: question,
+    }),
+
+  closeModal: () =>
+    set({
+      isOpen: false,
+    }),
+}));

--- a/features/my-questions/types/index.ts
+++ b/features/my-questions/types/index.ts
@@ -1,0 +1,19 @@
+export interface QuestionItem {
+  id: number;
+  applicationId: number;
+  interviewQuestionId: number | null;
+  question: string;
+  answer: string;
+  fromCommunity: boolean;
+  createdAt: string;
+  updatedAt: string;
+  company: string;
+  position: string;
+  interviewType: string;
+}
+
+export interface GetQuestionsResponse {
+  questions: QuestionItem[];
+  hasNext: boolean;
+  nextCursorId: number | null;
+}

--- a/mocks/handlers/index.ts
+++ b/mocks/handlers/index.ts
@@ -2,10 +2,12 @@ import { applicationHandlers } from './applications.handlers';
 import { calendarHandlers } from './calendars.handlers';
 import { interviewsHandlers } from './interviews.handlers';
 import { membersHandlers } from './members.handlers';
+import { questionsHandlers } from './questions.handlers';
 
 export const handlers = [
   ...applicationHandlers,
   ...calendarHandlers,
   ...membersHandlers,
   ...interviewsHandlers,
+  ...questionsHandlers,
 ];

--- a/mocks/handlers/questions.handlers.ts
+++ b/mocks/handlers/questions.handlers.ts
@@ -1,0 +1,48 @@
+import { http, HttpResponse } from 'msw';
+import { ENV } from '@/shared/constants/env';
+import { fakerKO as faker } from '@faker-js/faker';
+import { INTERVIEW_PRESETS } from '@/shared/constants/interview';
+
+export const questionsHandlers = [
+  http.get(`${ENV.BFF_API_URL}/v1/archive/questions`, ({ request }) => {
+    const url = new URL(request.url);
+    const cursor = url.searchParams.get('lastCursorId');
+    const limit = Number(url.searchParams.get('size')) || 20;
+
+    const selectedPreset = faker.helpers.arrayElement(INTERVIEW_PRESETS);
+
+    // 더미 데이터 생성 함수
+    const generateQuestions = (count: number) => {
+      return Array.from({ length: count }, (_, index) => ({
+        id: Number(cursor || 0) + index + 1,
+        applicationId: faker.number.int({ min: 1, max: 100 }),
+        interviewQuestionId: faker.number.int({ min: 1000, max: 9999 }),
+        question: `${faker.helpers.arrayElement([
+          '프로젝트 진행 중 갈등 상황을 어떻게 해결했나요',
+          '본인이 사용한 기술 스택의 장단점은 무엇인가요',
+          '협업 과정에서 가장 중요하게 생각하는 가치는',
+          '우리 회사에 지원하게 된 가장 큰 동기는',
+          '자신의 기술적 강점에 대해 설명해주세요',
+        ])} (${faker.lorem.word()} 관련)?`,
+        answer: faker.lorem.paragraphs(1), // 답변 내용
+        fromCommunity: faker.datatype.boolean(),
+        createdAt: faker.date.past().toISOString(),
+        updatedAt: faker.date.recent().toISOString(),
+        // 대시보드 UI 확인을 위해 추가될 수 있는 데이터들
+        company: faker.company.name(),
+        position: faker.person.jobTitle(),
+        interviewType: selectedPreset.value,
+      }));
+    };
+
+    const questions = generateQuestions(limit);
+    const hasNext = Number(cursor || 0) < 20; // 테스트를 위해 20개까지만 생성
+    const nextCursorId = hasNext ? questions[questions.length - 1].id : null;
+
+    return HttpResponse.json({
+      questions,
+      hasNext,
+      nextCursorId,
+    });
+  }),
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "career-hub",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.2.2",
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -29,8 +31,10 @@
         "react-big-calendar": "^1.19.4",
         "react-day-picker": "^9.12.0",
         "react-dom": "19.2.0",
+        "react-hook-form": "^7.70.0",
         "recharts": "^3.6.0",
         "tailwind-merge": "^3.4.0",
+        "zod": "^4.3.5",
         "zustand": "^5.0.9"
       },
       "devDependencies": {
@@ -547,6 +551,18 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -1473,6 +1489,52 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",
@@ -7493,6 +7555,22 @@
         "react": "^19.2.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.70.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.70.0.tgz",
+      "integrity": "sha512-COOMajS4FI3Wuwrs3GPpi/Jeef/5W1DRR84Yl5/ShlT3dKVFUfoGiEZ/QE6Uw8P4T2/CLJdcTVYKvWBMQTEpvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -9119,10 +9197,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
-      "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
-      "dev": true,
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
+      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
@@ -30,8 +32,10 @@
     "react-big-calendar": "^1.19.4",
     "react-day-picker": "^9.12.0",
     "react-dom": "19.2.0",
+    "react-hook-form": "^7.70.0",
     "recharts": "^3.6.0",
     "tailwind-merge": "^3.4.0",
+    "zod": "^4.3.5",
     "zustand": "^5.0.9"
   },
   "devDependencies": {

--- a/shared/components/ConfirmModal.tsx
+++ b/shared/components/ConfirmModal.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/shared/components/ui/alert-dialog';
+import { useConfirmStore } from '@/shared/stores/useConfirmStore';
+import { buttonVariants } from '@/shared/components/ui/button';
+
+export const ConfirmModal = () => {
+  const { isOpen, config, closeConfirm } = useConfirmStore();
+
+  const handleConfirm = () => {
+    config.onConfirm();
+    closeConfirm();
+  };
+
+  return (
+    <AlertDialog open={isOpen} onOpenChange={closeConfirm}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{config.title}</AlertDialogTitle>
+          <AlertDialogDescription>{config.description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={closeConfirm}>
+            {config.cancelText || '취소'}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleConfirm}
+            // variant가 destructive일 경우 빨간 버튼으로 표시
+            className={buttonVariants({ variant: config.variant || 'default' })}
+          >
+            {config.confirmText || '확인'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};

--- a/shared/components/RelativeTime.tsx
+++ b/shared/components/RelativeTime.tsx
@@ -1,0 +1,20 @@
+import { formatDistanceToNow } from 'date-fns';
+import { ko } from 'date-fns/locale';
+
+interface RelativeTimeProps {
+  date: string | Date;
+  className?: string;
+}
+
+export const RelativeTime = ({ date, className }: RelativeTimeProps) => {
+  const d = typeof date === 'string' ? new Date(date) : date;
+
+  return (
+    <time dateTime={d.toISOString()} className={className}>
+      {formatDistanceToNow(d, {
+        addSuffix: true, // '전' 또는 '후'를 자동으로 붙여줌
+        locale: ko, // 한국어 설정
+      })}
+    </time>
+  );
+};

--- a/shared/components/providers/index.tsx
+++ b/shared/components/providers/index.tsx
@@ -1,3 +1,4 @@
+import { ConfirmModal } from '../ConfirmModal';
 import MswProvider from './MswProvider';
 import TanstackQueryProvider from './TanstackQueryProvider';
 
@@ -5,7 +6,10 @@ export default function Providers({ children }: { children: React.ReactNode }) {
   return (
     <>
       <MswProvider>
-        <TanstackQueryProvider>{children}</TanstackQueryProvider>
+        <TanstackQueryProvider>
+          <ConfirmModal />
+          {children}
+        </TanstackQueryProvider>
       </MswProvider>
     </>
   );

--- a/shared/components/ui/alert-dialog.tsx
+++ b/shared/components/ui/alert-dialog.tsx
@@ -1,0 +1,157 @@
+"use client"
+
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/shared/lib/utils"
+import { buttonVariants } from "@/shared/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/shared/components/ui/skeleton.tsx
+++ b/shared/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/shared/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("bg-accent animate-pulse rounded-md", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/shared/constants/interview.ts
+++ b/shared/constants/interview.ts
@@ -1,0 +1,18 @@
+export const INTERVIEW_PRESETS = [
+  { value: 'TECH', label: '기술 면접' },
+  { value: 'FIT', label: '컬처핏/인성 면접' },
+  { value: 'EXECUTIVE', label: '임원 면접' },
+  { value: 'DESIGN', label: '시스템 디자인 면접' },
+  { value: 'TEST', label: '라이브 코딩 테스트 면접' },
+  { value: 'ETC', label: '기타' },
+] as const;
+
+// Value를 Key로 하는 매핑 객체
+export const INTERVIEW_LABEL_MAP: Record<string, string> =
+  INTERVIEW_PRESETS.reduce(
+    (acc, curr) => ({ ...acc, [curr.value]: curr.label }),
+    {}
+  );
+
+// 타입 추론을 위한 유니온 타입 생성 (선택 사항)
+export type InterviewType = (typeof INTERVIEW_PRESETS)[number]['value'];

--- a/shared/hooks/useInView.ts
+++ b/shared/hooks/useInView.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState, useRef, useCallback } from 'react';
+
+interface UseInViewOptions extends IntersectionObserverInit {
+  triggerOnce?: boolean; // 한 번만 감지할지 여부
+}
+
+export const useInView = (options?: UseInViewOptions) => {
+  const [inView, setInView] = useState(false);
+  const [node, setNode] = useState<HTMLElement | null>(null);
+  const observer = useRef<IntersectionObserver | null>(null);
+
+  // ref를 함수형으로 정의하여 DOM 요소가 마운트될 때 setNode를 호출합니다.
+  const ref = useCallback((node: HTMLElement | null) => {
+    setNode(node);
+  }, []);
+
+  useEffect(() => {
+    // 이전 옵저버가 있다면 연결 해제
+    if (observer.current) observer.current.disconnect();
+
+    if (node) {
+      observer.current = new IntersectionObserver(([entry]) => {
+        const isIntersecting = entry.isIntersecting;
+        setInView(isIntersecting);
+
+        // 한 번만 실행 옵션이 있고 화면에 들어왔다면 관찰 중단
+        if (isIntersecting && options?.triggerOnce) {
+          observer.current?.unobserve(node);
+        }
+      }, options);
+
+      observer.current.observe(node);
+    }
+
+    // 컴포넌트 언마운트 시 정리
+    return () => {
+      if (observer.current) observer.current.disconnect();
+    };
+  }, [node, options]);
+
+  return { ref, inView };
+};

--- a/shared/lib/api/clientApi.ts
+++ b/shared/lib/api/clientApi.ts
@@ -29,5 +29,27 @@ export const clientApi = {
       body: JSON.stringify(body),
     });
   },
-  // put, delete 등 필요한 메서드 추가
+
+  put<T>(path: string, body: unknown, options?: RequestInit) {
+    return this.request<T>(path, {
+      ...options,
+      method: 'PUT',
+      body: JSON.stringify(body),
+    });
+  },
+
+  patch<T>(path: string, body: unknown, options?: RequestInit) {
+    return this.request<T>(path, {
+      ...options,
+      method: 'PATCH',
+      body: JSON.stringify(body),
+    });
+  },
+
+  delete<T>(path: string, options?: RequestInit) {
+    return this.request<T>(path, {
+      ...options,
+      method: 'DELETE',
+    });
+  },
 };

--- a/shared/lib/api/errors.ts
+++ b/shared/lib/api/errors.ts
@@ -1,0 +1,23 @@
+// 백엔드와 약속한 에러 응답 구조 타입
+export interface BackendErrorResponse {
+  statusCode: number;
+  message: string;
+  validation?: Record<string, string>;
+}
+
+export class ApiError extends Error {
+  statusCode: number;
+  validation?: Record<string, string>;
+
+  constructor(data: BackendErrorResponse) {
+    // 백엔드 메시지가 없으면 상태 코드를 기본 메시지로 사용
+    super(data.message || `서버 에러가 발생했습니다.`);
+
+    this.name = 'ApiError';
+    this.statusCode = data.statusCode;
+    this.validation = data.validation;
+
+    // 인스턴스 체크(instanceof)가 정상 작동하게 하기 위함
+    Object.setPrototypeOf(this, ApiError.prototype);
+  }
+}

--- a/shared/lib/api/serverApi.ts
+++ b/shared/lib/api/serverApi.ts
@@ -1,6 +1,7 @@
 import { cookies } from 'next/headers';
 import { ENV } from '@/shared/constants/env';
 import { setAuthSession } from '@/features/login/server-actions/auth'; // 쿠키 설정을 위해 기존 서버 액션 재사용
+import { ApiError, BackendErrorResponse } from './errors';
 
 // 동시 요청 제어를 위한 변수 (모듈 스코프에 위치)
 let isRefreshing = false;
@@ -70,11 +71,6 @@ export async function serverApi<T>(
     redirect: 'manual',
   });
 
-  console.log(
-    `Debug: Initial fetch to ${path} completed with status:`,
-    response.status
-  );
-
   if (response.status === 401) {
     if (!isRefreshing) {
       // 첫 번째 요청이 리프레시 로직을 실행하고, Promise를 할당
@@ -88,9 +84,11 @@ export async function serverApi<T>(
     try {
       // 후속 요청들은 진행중인 리프레시 Promise가 끝나기를 기다림
       const newAccessToken = await refreshPromise;
-      headers.set('Authorization', `Bearer ${newAccessToken}`);
-      // 재요청
-      response = await fetch(backendUrl, { ...options, headers });
+      if (newAccessToken) {
+        headers.set('Authorization', `Bearer ${newAccessToken}`);
+        // 재요청 실행
+        response = await fetch(backendUrl, { ...options, headers });
+      }
     } catch (error) {
       // 리프레시 자체가 실패한 경우 (세션 만료 등)
       // 에러를 그대로 던져서 최종 에러 처리 로직으로 전달
@@ -99,11 +97,12 @@ export async function serverApi<T>(
   }
 
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
-    // 백엔드 에러 메시지를 우선적으로 사용
-    throw new Error(
-      errorData.message || `HTTP error! status: ${response.status}`
-    );
+    const errorData: BackendErrorResponse = await response.json().catch(() => ({
+      statusCode: response.status,
+      message: '알 수 없는 에러가 발생했습니다.',
+    }));
+
+    throw new ApiError(errorData);
   }
 
   return response.json();

--- a/shared/lib/tanstack-query/get-query-client.ts
+++ b/shared/lib/tanstack-query/get-query-client.ts
@@ -8,7 +8,9 @@ function makeQueryClient() {
   return new QueryClient({
     defaultOptions: {
       queries: {
-        staleTime: 60 * 1000,
+        staleTime: 0,
+        gcTime: 0,
+        refetchOnWindowFocus: false,
       },
       dehydrate: {
         // include pending queries in dehydration

--- a/shared/stores/useConfirmStore.ts
+++ b/shared/stores/useConfirmStore.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand';
+
+interface ConfirmConfig {
+  title: string;
+  description: string;
+  confirmText?: string;
+  cancelText?: string;
+  variant?: 'default' | 'destructive';
+  onConfirm: () => void;
+}
+
+interface ConfirmStore {
+  isOpen: boolean;
+  config: ConfirmConfig;
+  openConfirm: (config: ConfirmConfig) => void;
+  closeConfirm: () => void;
+}
+
+export const useConfirmStore = create<ConfirmStore>((set) => ({
+  isOpen: false,
+  config: {
+    title: '',
+    description: '',
+    onConfirm: () => {},
+  },
+  openConfirm: (config) => set({ isOpen: true, config }),
+  closeConfirm: () => set({ isOpen: false }),
+}));


### PR DESCRIPTION
## PR 타입

- [x] feat
- [ ] fix
- [ ] refactor
- [ ] chore
- [ ] docs
- [ ] test
- [x] setting

## 요약

- 유저가 본인의 면접 질문을 관리할 수 있는 '나의 질문' 페이지를 구축하고, 무한 스크롤 기반의 CRUD 기능을 구현했습니다.

## 주요 변경 사항

1. '나의 질문' 대시보드 및 CRUD 구현
- 목록 조회: useInfiniteQuery를 활용한 무한 스크롤 목록 구현.
- C/U/D 기능: 질문 생성, 수정, 삭제 기능 및 API 연동 완료.
- UI 구성: MyQuestionsHeader, Searchbar, QuestionList 등 컴포넌트 기반 아키텍처 적용.

2. 전역 상태 및 공통 UI 컴포넌트 도입
- Zustand Store: 질문 작성 모달(useQuestionModalStore) 및 공통 확인 모달(useConfirmStore) 상태 관리 추가.
- 공통 모달: 삭제 확인 등을 위한 선언적 Confirm 모달 UI 구현.

3. 데이터 패칭 및 에러 핸들링 최적화
- TanStack Query: 클라이언트 사이드 데이터 패칭 전략으로 사용자 경험(UX) 개선.
- 에러 처리: ApiError 클래스 및 BackendErrorResponse 타입을 정의하여 체계적인 백엔드 에러 대응.
- 날짜 라이브러리: date-fns를 도입하여 '방금 전', 'n시간 전' 등 상대 시간 표시 기능 구현.

4. 라이브러리 설정 추가
- react-hook-form, zod, @hookform/resolvers를 설치하여 폼 검증 로직 표준화.

## Before / After (선택)

- 변경 전/후 차이를 설명하거나 스크린샷을 첨부해주세요.

## 관련 이슈

- #9 

## 테스트 방법

1. /questions 경로로 접속하여 초기 질문 목록 로드 및 스켈레톤 UI 확인.
2. 상단 '질문 등록' 버튼을 통해 신규 질문 생성 테스트.
3. 각 질문 아이템의 수정/삭제 버튼을 눌러 CRUD 동작 및 모달 정상 작동 확인.
4. 스크롤 하단 도달 시 무한 스크롤 데이터 페칭 검증.

## 체크리스트

- [x] 기능이 의도대로 동작하는지 self-review 포함하여 확인했습니다.
- [x] 불필요한 파일/주석/console.log는 제거했습니다.
- [x] 라우터/스토어/전역 상태 변경 시 영향 범위를 확인했습니다.
- [x] 브레이킹 체인지가 있다면 문서/주석을 업데이트했습니다.
- [x] 커밋 메시지가 컨벤션을 따릅니다.

## 리스크 (선택)

- 변경이 다른 기능에 영향을 줄 가능성이 있다면 작성해주세요.

## 문서 갱신 여부

- [x] 문서 업데이트가 필요 없습니다.
- [ ] 문서 업데이트를 완료했습니다.

## 기타 참고 사항

- 리뷰어가 이해하는 데 도움이 되는 내용을 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * "나만의 면접 질문 모음" 섹션 추가: 면접 질문을 생성, 편집, 삭제할 수 있는 전용 페이지 제공
  * 회사명 기반 검색 기능: 저장된 질문을 빠르게 찾을 수 있는 검색바 추가
  * 무한 스크롤: 질문 목록을 자동으로 로드하여 부드러운 탐색 경험 제공
  * 질문 상세 정보: 회사명, 직무, 면접 유형, 작성 일시 등 메타데이터 표시

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->