### PR TITLE
Fix: PWA 설치 불가 에러 & ios 설정

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,11 @@ export const metadata: Metadata = {
   title: 'Career-Hub',
   description:
     '구직자의 지원 현황·자소서·면접 일정을 한 곳에서 관리하는 통합 플랫폼 SaaS 서비스',
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: 'default',
+    title: 'Career-Hub',
+  },
 };
 
 export default function RootLayout({

--- a/middleware.ts
+++ b/middleware.ts
@@ -23,10 +23,10 @@ export const config = {
    * 1. api (BFF API Route)
    * 2. _next/static (정적 파일)
    * 3. _next/image (이미지 최적화 파일)
-   * 4. favicon.ico, manifest.ts (루트 정적 파일)
+   * 4. favicon.ico, manifest.webmanifest (루트 정적 파일)
    * 5. .png, .svg 등 이미지 확장자
    */
   matcher: [
-    '/((?!api|_next/static|_next/image|favicon.ico|manifest.ts|.*\\.png$|.*\\.svg$).*)',
+    '/((?!api|_next/static|_next/image|favicon.ico|manifest.webmanifest|firebase-messaging-sw\\.js|.*\\.png$|.*\\.svg$).*)',
   ],
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,45 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+        ],
+      },
+      {
+        source: '/firebase-messaging-sw.js',
+        headers: [
+          {
+            key: 'Content-Type',
+            value: 'application/javascript; charset=utf-8',
+          },
+          {
+            key: 'Cache-Control',
+            value: 'no-cache, no-store, must-revalidate',
+          },
+          {
+            key: 'Content-Security-Policy',
+            value:
+              "default-src 'self'; script-src 'self' https://www.gstatic.com",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## PR 타입

- [ ] feat
- [x] fix
- [ ] refactor
- [ ] chore
- [ ] docs
- [ ] test
- [x] setting

## 요약

  - PWA manifest가 middleware 인증 리다이렉트에 의해  
  HTML로 반환되는 문제를 수정하고, PWA 보안 헤더 및   
  iOS 지원 설정을 추가했습니다.

## 주요 변경 사항

  - middleware.ts: matcher에서 제외할 경로를 소스     
  파일명(manifest.ts)에서 실제 서빙
  경로(manifest.webmanifest)로 수정하여 manifest      
  요청이 인증 리다이렉트를 타지 않도록 수정.
  firebase-messaging-sw.js도 제외 목록에 추가.        
  - next.config.ts: PWA 보안 헤더 추가
  (X-Content-Type-Options, X-Frame-Options,
  Referrer-Policy) 및 firebase-messaging-sw.js 전용   
  헤더 설정 (Content-Type, Cache-Control, CSP).       
  - app/layout.tsx: iOS Safari에서 홈 화면 추가 시    
  전체화면 웹앱으로 동작하도록 appleWebApp 메타데이터 
  추가.
  - app/manifest.ts (미커밋): short_name을 'CareerHub'
   → 'Career Hub'으로 변경하여 가독성 개선.

## Before / After

  - Before: 브라우저가 /manifest.webmanifest 요청 시  
  middleware가 가로채서 /로 리다이렉트 → HTML 응답 →  
  Line: 1, column: 1, Syntax error 발생, PWA 설치 불가
  - After: manifest 요청이 middleware를 우회하여 정상 
  JSON 응답 반환, PWA 정상 동작

## 관련 이슈

  - Close #44

## 테스트 방법

  1. npm run dev로 로컬 서버 실행
  2. 브라우저 DevTools > Application > Manifest 탭에  
   manifest가 정상적으로 로드되는지 확인
  3. Manifest 항목에 Syntax error가 발생하지 않는지   
  확인
  4. 로그아웃 상태에서도 /manifest.webmanifest 접근   
   JSON이 반환되는지 확인

## 체크리스트

  - [x] 기능이 의도대로 동작하는지 self-review 포함하여   
  확인했습니다.
  - [x] 불필요한 파일/주석/console.log는 제거했습니다.    
  - [x]라우터/스토어/전역 상태 변경 시 영향 범위를       
  확인했습니다.
  - [x] 브레이킹 체인지가 있다면 문서/주석을
  업데이트했습니다.
  - [x] 커밋 메시지가 컨벤션을 따릅니다.

## 문서 갱신 여부

  - 문서 업데이트가 필요 없습니다.
## 기타 참고 사항

- 리뷰어가 이해하는 데 도움이 되는 내용을 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능
* Apple 웹 앱 메타데이터 및 상태 표시줄 설정 추가

## 개선사항
* 보안 헤더 및 콘텐츠 타입 설정 추가
* 라우팅 규칙 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->